### PR TITLE
BugFix: Checking the Response Header

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -84,7 +84,7 @@ class Client
 
 			if ($response->code >= 200 && $response->code < 400)
 			{
-				if ($response->headers['Content-Type'] == 'application/json')
+				if (strpos($response->headers['Content-Type'], 'application/json'))
 				{
 					$token = array_merge(json_decode($response->body, true), array('created' => time()));
 				}


### PR DESCRIPTION
The former check of the response header did not accout for all possible response headers. Google for example sends a header

Content-Type: application/json; charset=utf-8

This leads to errors since the return json objects is not parsed correctly
