### PR TITLE
Fix the use of Joomla\Http\Response

### DIFF
--- a/Tests/ClientTest.php
+++ b/Tests/ClientTest.php
@@ -35,7 +35,7 @@ class ClientTest extends TestCase
 	 *
 	 * @var  Http|MockObject
 	 */
-	protected $client;
+	protected $http;
 
 	/**
 	 * The input object to use in retrieving GET/POST data.

--- a/Tests/ClientTest.php
+++ b/Tests/ClientTest.php
@@ -8,9 +8,11 @@ namespace Joomla\OAuth2\Tests;
 
 use Joomla\Application\WebApplicationInterface;
 use Joomla\Http\Http;
+use Joomla\Http\Response;
 use Joomla\Input\Input;
 use Joomla\OAuth2\Client;
 use Joomla\Registry\Registry;
+use Laminas\Diactoros\StreamFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -347,13 +349,11 @@ class ClientTest extends TestCase
 	 */
 	public function encodedGrantOauthCallback($url, $data, array $headers = null, $timeout = null)
 	{
-		$response = new \stdClass;
-
-		$response->code    = 200;
-		$response->headers = ['Content-Type' => 'x-www-form-urlencoded'];
-		$response->body    = 'access_token=accessvalue&refresh_token=refreshvalue&expires_in=3600';
-
-		return $response;
+		return new Response(
+			(new StreamFactory)->createStream('access_token=accessvalue&refresh_token=refreshvalue&expires_in=3600'),
+			200,
+			['Content-Type' => 'x-www-form-urlencoded']
+		);
 	}
 
 	/**
@@ -368,13 +368,11 @@ class ClientTest extends TestCase
 	 */
 	public function jsonGrantOauthCallback($url, $data, array $headers = null, $timeout = null)
 	{
-		$response = new \stdClass;
-
-		$response->code    = 200;
-		$response->headers = ['Content-Type' => 'application/json'];
-		$response->body    = '{"access_token":"accessvalue","refresh_token":"refreshvalue","expires_in":3600}';
-
-		return $response;
+		return new Response(
+			(new StreamFactory)->createStream('{"access_token":"accessvalue","refresh_token":"refreshvalue","expires_in":3600}'),
+			200,
+			['CONTENT-TYPE' => 'application/json']
+		);
 	}
 
 	/**
@@ -389,13 +387,11 @@ class ClientTest extends TestCase
 	 */
 	public function queryOauthCallback($url, $data, array $headers = null, $timeout = null)
 	{
-		$response = new \stdClass;
-
-		$response->code    = 200;
-		$response->headers = ['Content-Type' => 'text/html'];
-		$response->body    = 'Lorem ipsum dolor sit amet.';
-
-		return $response;
+		return new Response(
+			(new StreamFactory)->createStream('Lorem ipsum dolor sit amet.'),
+			200,
+			['Content-Type' => 'text/html']
+		);
 	}
 
 	/**
@@ -409,12 +405,10 @@ class ClientTest extends TestCase
 	 */
 	public function getOauthCallback($url, array $headers = null, $timeout = null)
 	{
-		$response = new \stdClass;
-
-		$response->code    = 200;
-		$response->headers = ['Content-Type' => 'text/html'];
-		$response->body    = 'Lorem ipsum dolor sit amet.';
-
-		return $response;
+		return new Response(
+			(new StreamFactory)->createStream('Lorem ipsum dolor sit amet.'),
+			200,
+			['Content-Type' => ['text/html']]
+		);
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require-dev": {
         "joomla/coding-standards": "^3.0@dev",
-        "phpunit/phpunit": "^8.5|^9.0"
+        "phpunit/phpunit": "^8.5|^9.0",
+        "laminas/laminas-diactoros": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -12,7 +12,6 @@ use Joomla\Application\WebApplicationInterface;
 use Joomla\Http\Exception\UnexpectedResponseException;
 use Joomla\Http\Http;
 use Joomla\Http\HttpFactory;
-use Joomla\Http\Response;
 use Joomla\Input\Input;
 use Joomla\Uri\Uri;
 
@@ -114,7 +113,7 @@ class Client
 				);
 			}
 
-			if (self::isJsonResponse($response))
+			if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== false)
 			{
 				$token = array_merge(json_decode((string) $response->getBody(), true), ['created' => time()]);
 			}
@@ -407,7 +406,7 @@ class Client
 			);
 		}
 
-		if (self::isJsonResponse($response))
+		if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== false)
 		{
 			$token = array_merge(json_decode((string) $response->getBody(), true), ['created' => time()]);
 		}
@@ -420,27 +419,5 @@ class Client
 		$this->setToken($token);
 
 		return $token;
-	}
-
-	/**
-	 * Tests if given response contains JSON header
-	 *
-	 * @param   Response  $response  The response object
-	 *
-	 * @return  boolean
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	private static function isJsonResponse(Response $response): bool
-	{
-		foreach ($response->getHeader('Content-Type') as $value)
-		{
-			if (strpos($value, 'application/json') !== false)
-			{
-				return true;
-			}
-		}
-
-		return false;
 	}
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -427,7 +427,7 @@ class Client
 	 *
 	 * @param   Response  $response  The response object
 	 *
-	 * @return  bool
+	 * @return  boolean
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */


### PR DESCRIPTION
### Summary of Changes

Fixes the use `Joomla\Http\Response` where the values of individual headers are stored as arrays since v2 of the `joomla/http` package. Closes https://github.com/joomla-framework/oauth2/issues/19.
Updates to use `joomla/http` v2 syntax only since v1 support was dropped for some reason in https://github.com/joomla-framework/oauth2/commit/59268f587cfc4e8a1b75074fad610bc7d96ca7bf.
Updates tests to also use `Joomla\Http\Response` class (the use of `stdClass` is what allowed the error to slip by).

### Testing Instructions
Use the class. Before patch, `TypeError` is thrown in `src\Client.php:116 ` on PHP 8:

    strpos(): Argument #1 ($haystack) must be of type string, array given 
On older PHP versions, a warning is emitted and JSON header detection always fails:

    Warning: strpos() expects parameter 1 to be string, array given

### Documentation Changes Required
No.