### PR TITLE
Fix missing code param in authentication request

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -90,13 +90,14 @@ class Client
 	 */
 	public function authenticate()
 	{
-		if ($data['code'] = $this->input->get('code', false, 'raw'))
+		if ($dataCode = $this->input->get('code', false, 'raw'))
 		{
 			$data = [
 				'grant_type'    => 'authorization_code',
 				'redirect_uri'  => $this->getOption('redirecturi'),
 				'client_id'     => $this->getOption('clientid'),
 				'client_secret' => $this->getOption('clientsecret'),
+				'code'    	=> $dataCode,
 			];
 
 			$response = $this->http->post($this->getOption('tokenurl'), $data);


### PR DESCRIPTION
Pull Request for Issue #17
The $data array for the authentication request is overwritten after delcaring the value and key for the code parameter, so $data['code'] is missing.

### Summary of Changes
Declared variable in if-condition and added code key => value to the data array.

### Testing Instructions

### Documentation Changes Required
no documentation available yet
