### PR TITLE
[4.0] Change access to body of Response object

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -109,15 +109,15 @@ class Client
                     sprintf(
                         'Error code %s received requesting access token: %s.',
                         $response->getStatusCode(),
-                        $response->getBody()->getContents()
+                        (string) $response->getBody()
                     )
                 );
             }
 
             if (in_array('application/json', $response->getHeader('Content-Type'))) {
-                $token = array_merge(json_decode($response->getBody()->getContents(), true), ['created' => time()]);
+                $token = array_merge(json_decode((string) $response->getBody(), true), ['created' => time()]);
             } else {
-                parse_str($response->getBody()->getContents(), $token);
+                parse_str((string) $response->getBody(), $token);
                 $token = array_merge($token, ['created' => time()]);
             }
 
@@ -383,15 +383,15 @@ class Client
                 sprintf(
                     'Error code %s received refreshing token: %s.',
                     $response->getStatusCode(),
-                    $response->getBody()->getContents()
+                    (string) $response->getBody()
                 )
             );
         }
 
         if (in_array('application/json', $response->getHeader('Content-Type'))) {
-            $token = array_merge(json_decode($response->getBody()->getContents(), true), ['created' => time()]);
+            $token = array_merge(json_decode((string) $response->getBody(), true), ['created' => time()]);
         } else {
-            parse_str($response->getBody()->getContents(), $token);
+            parse_str((string) $response->getBody(), $token);
             $token = array_merge($token, ['created' => time()]);
         }
 


### PR DESCRIPTION
### Summary of Changes
When converting the code to v4 of the Joomla HTTP package, the method `Response->getBody()->getContents()` was used to access the body of the response, which can be problematic, when the pointer of the internal stream is not set to the beginning. This PR changes the code to use the magic `__toString()` method of the `StreamInterface` instead.

### Testing Instructions
Codereview

### Documentation Changes Required
none