### PR TITLE
Fix: case insesitive Content-Type header check for json response

### DIFF
--- a/Tests/ClientTest.php
+++ b/Tests/ClientTest.php
@@ -9,6 +9,7 @@ namespace Joomla\OAuth2\Tests;
 
 use Joomla\Application\WebApplicationInterface;
 use Joomla\Http\Http;
+use Joomla\Http\Response;
 use Joomla\Input\Input;
 use Joomla\OAuth2\Client;
 use Joomla\Registry\Registry;
@@ -34,7 +35,7 @@ class ClientTest extends TestCase
      *
      * @var  Http|MockObject
      */
-    protected $client;
+    protected $http;
 
     /**
      * The input object to use in retrieving GET/POST data.
@@ -348,11 +349,7 @@ class ClientTest extends TestCase
      */
     public function encodedGrantOauthCallback($url, $data, ?array $headers = null, $timeout = null)
     {
-        $response = new \stdClass();
-
-        $response->code    = 200;
-        $response->headers = ['Content-Type' => 'x-www-form-urlencoded'];
-        $response->body    = 'access_token=accessvalue&refresh_token=refreshvalue&expires_in=3600';
+        $response = new Response('data://text/plain,access_token=accessvalue&refresh_token=refreshvalue&expires_in=3600', 200, ['Content-Type' => 'x-www-form-urlencoded']);
 
         return $response;
     }
@@ -369,11 +366,7 @@ class ClientTest extends TestCase
      */
     public function jsonGrantOauthCallback($url, $data, ?array $headers = null, $timeout = null)
     {
-        $response = new \stdClass();
-
-        $response->code    = 200;
-        $response->headers = ['Content-Type' => 'application/json'];
-        $response->body    = '{"access_token":"accessvalue","refresh_token":"refreshvalue","expires_in":3600}';
+        $response = new Response('data://text/plain,{"access_token":"accessvalue","refresh_token":"refreshvalue","expires_in":3600}', 200, ['Content-Type' => 'application/json']);
 
         return $response;
     }
@@ -390,11 +383,7 @@ class ClientTest extends TestCase
      */
     public function queryOauthCallback($url, $data, ?array $headers = null, $timeout = null)
     {
-        $response = new \stdClass();
-
-        $response->code    = 200;
-        $response->headers = ['Content-Type' => 'text/html'];
-        $response->body    = 'Lorem ipsum dolor sit amet.';
+        $response = new Response('data://text/plain,Lorem ipsum dolor sit amet.', 200, ['Content-Type' => 'text/html']);
 
         return $response;
     }
@@ -410,11 +399,7 @@ class ClientTest extends TestCase
      */
     public function getOauthCallback($url, ?array $headers = null, $timeout = null)
     {
-        $response = new \stdClass();
-
-        $response->code    = 200;
-        $response->headers = ['Content-Type' => 'text/html'];
-        $response->body    = 'Lorem ipsum dolor sit amet.';
+        $response = new Response('data://text/plain,Lorem ipsum dolor sit amet.', 200, ['Content-Type' => 'text/html']);
 
         return $response;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -112,7 +112,7 @@ class Client
                 );
             }
 
-            if (strpos($response->headers['Content-Type'], 'application/json') !== false) {
+            if (in_array('application/json', $response->getHeader('Content-Type'))) {
                 $token = array_merge(json_decode($response->body, true), ['created' => time()]);
             } else {
                 parse_str($response->body, $token);
@@ -380,7 +380,7 @@ class Client
             );
         }
 
-        if (strpos($response->headers['Content-Type'], 'application/json') !== false) {
+        if (in_array('application/json', $response->getHeader('Content-Type'))) {
             $token = array_merge(json_decode($response->body, true), ['created' => time()]);
         } else {
             parse_str($response->body, $token);


### PR DESCRIPTION
Pull Request for Issue #31
Alternaitve to PR #31 
Backported fix from 4.x PR #33 / commit https://github.com/joomla-framework/oauth2/pull/33/commits/ff5fd802491561c15f997c3e8f2249b536dfbae2
Modified Test accordingly to use response directly, similar to PR #33 / commit https://github.com/joomla-framework/oauth2/pull/33/commits/f8cdce7d5dcf8a6050f75834f67507d9ba4be06e

### Summary of Changes

Use response getHeader function to check header case insensitive for potential json response.

### Testing Instructions

### Documentation Changes Required
